### PR TITLE
feat(npm-blacklist): scan multiple directories in one call

### DIFF
--- a/.github/actions/npm-blacklist/action.yml
+++ b/.github/actions/npm-blacklist/action.yml
@@ -10,6 +10,15 @@ inputs:
     description: 'Path to the NPM project, example: ./packages/my-npm-project'
     required: false
     default: '.'
+  working-directories:
+    description: >-
+      Whitespace-separated list of NPM project paths to scan in one invocation,
+      example: a YAML multiline of ". packages/foo packages/bar". Takes
+      precedence over `working-directory` when set; the checker runs against
+      every listed directory and fails if any of them resolves a blacklisted
+      package.
+    required: false
+    default: ''
   additional-blacklist-file:
     description: 'Path to an additional file with list of packages in form of "pkg@version", example: ./my-blacklist.txt'
     required: false
@@ -29,13 +38,25 @@ runs:
       shell: bash
       env:
         WORKING_DIRECTORY: ${{ inputs['working-directory'] }}
+        WORKING_DIRECTORIES: ${{ inputs['working-directories'] }}
         DEFAULT_BLACKLIST: ${{ github.action_path }}/blacklist.txt
         ADDITIONAL_BLACKLIST_FILE: ${{ inputs['additional-blacklist-file'] }}
         ADDITIONAL_BLACKLIST_PKGS: ${{ inputs['additional-blacklist-pkgs'] }}
         OVERRIDE_BLACKLIST: ${{ inputs['override-blacklist'] }}
+      # `working-directories` (whitespace-separated) lets one action call scan
+      # several NPM projects from a single installed dependency tree; it takes
+      # precedence over the singular `working-directory`. Word-splitting the
+      # list is intentional, so IFS-splitting is left on for the loop. Every
+      # directory is checked even if an earlier one fails, and a non-zero exit
+      # from any directory fails the step.
       run: |
-        ${{ github.action_path }}/checker.sh \
-        "${WORKING_DIRECTORY}" \
-        "${OVERRIDE_BLACKLIST:-$DEFAULT_BLACKLIST}" \
-        "${ADDITIONAL_BLACKLIST_FILE}" \
-        "${ADDITIONAL_BLACKLIST_PKGS}"
+        dirs="${WORKING_DIRECTORIES:-$WORKING_DIRECTORY}"
+        rc=0
+        for dir in $dirs; do
+          "${{ github.action_path }}/checker.sh" \
+            "$dir" \
+            "${OVERRIDE_BLACKLIST:-$DEFAULT_BLACKLIST}" \
+            "${ADDITIONAL_BLACKLIST_FILE}" \
+            "${ADDITIONAL_BLACKLIST_PKGS}" || rc=1
+        done
+        exit "$rc"


### PR DESCRIPTION
## What

Adds a `working-directories` input to the `npm-blacklist` composite action: a whitespace-separated list of NPM project paths to scan in a single action call, from one already-installed dependency tree.

- `working-directories` takes precedence over the singular `working-directory` when set.
- The action loops `checker.sh` over each listed directory. Every directory is checked (an early failure doesn't short-circuit), and the step fails if any directory resolves a blacklisted package.
- Fully backward compatible: existing callers that pass only `working-directory` (or nothing) are unchanged.

## Why

CI today calls this composite action once **per** workspace package (e.g. `.`, `packages/raindex`, `packages/ui-components`), which is fine for a static list hand-written inline. But a parameterized reusable workflow can't loop a composite `uses:` over a dynamic list in YAML — its only options are to bake a fixed call count in, or run a matrix that re-installs the (expensive) dependency tree per directory.

Giving the action itself a multi-directory mode lets a reusable workflow install **once** and scan all directories in a single step. This is the right home for the loop: the directory iteration is the action's concern, not each consumer's.

## Companion PR

This unblocks the install-once design of `rainlanguage/rainix`'s new `rainix-npm-blacklist.yaml` reusable workflow (rainlanguage/rainix#229), which calls this action once with the full `working-directories` list after a single install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)